### PR TITLE
Task routes/be setup

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -63,7 +63,7 @@ router.delete("/", isLoggedIn, async (req, res, next) => {
     }
 });
 
-// Get a users  profile regardless of login status
+// Get a users profile regardless of login status
 router.get("/:userSlug", async (req, res) => {
     try {
         let profile = await User.findOne({ slug: req.params.userSlug });


### PR DESCRIPTION
Route adjustments:
* adding endpoint: `/task/accept-interest/:taskId` - will only allow the creator of the task to update the acceptedStatus of the volunteer to no or yes. Handles edgecase if volunteer is not found.
